### PR TITLE
Implementing scientific notation for numbers

### DIFF
--- a/lizzie.tests/Parser.cs
+++ b/lizzie.tests/Parser.cs
@@ -37,6 +37,30 @@ namespace lizzie.tests
         }
 
         [Test]
+        public void InlineFloatingPointInScientificNotationSymbol()
+        {
+            var code = "57.67e2";
+            var tokenizer = new Tokenizer(new LizzieTokenizer());
+            var function = Compiler.Compile<LambdaCompiler.Nothing>(tokenizer, code);
+            var ctx = new LambdaCompiler.Nothing();
+            var binder = new Binder<LambdaCompiler.Nothing>();
+            var result = function(ctx, binder);
+            Assert.AreEqual(5767.0, result);
+        }
+
+        [Test]
+        public void InlineFloatingPointInScientificNotationWithNegativeExponentSymbol()
+        {
+            var code = "5767e-2";
+            var tokenizer = new Tokenizer(new LizzieTokenizer());
+            var function = Compiler.Compile<LambdaCompiler.Nothing>(tokenizer, code);
+            var ctx = new LambdaCompiler.Nothing();
+            var binder = new Binder<LambdaCompiler.Nothing>();
+            var result = function(ctx, binder);
+            Assert.AreEqual(57.67, result);
+        }
+
+        [Test]
         public void InlineStringSymbol()
         {
             var code = @"""57""";

--- a/lizzie/Compiler.cs
+++ b/lizzie/Compiler.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2018 Thomas Hansen - thomas@gaiasoul.com
  *
  * Licensed under the terms of the MIT license, see the enclosed LICENSE
@@ -288,7 +288,7 @@ namespace lizzie
             object numericConstant = null;
 
             // Checking if this is a floating point value.
-            if (en.Current.Contains('.')) {
+            if (en.Current.IndexOfAny(new[] { '.', 'e', 'E' }) != -1) {
 
                 // Notice, all floating point numbers are treated as double.
                 var success = double.TryParse(en.Current, NumberStyles.Any, CultureInfo.InvariantCulture, out double dblResult);
@@ -397,13 +397,40 @@ namespace lizzie
          */
         static bool IsNumeric(string symbol)
         {
-            if (symbol[0] == '-' && symbol.Length > 1)
-                symbol = symbol.Substring(1);
-            foreach (var ix in symbol) {
-                if ((ix < '0' || ix > '9') && ix != '.')
+            // To support scientific notation, split the number into the base and exponent parts, 
+            // which will be seperated by an 'E' character.
+            var parts = symbol.Split('e', 'E');
+
+            // All valid numbers will either have one or two parts, the coefficient will always be the first part.
+            string coefficient = SanitizeSign(parts[0]);
+
+            // If we have two parts we need to check the exponent.
+            if (parts.Length == 2)
+            {
+                var exponent = SanitizeSign(parts[1]);
+                if (exponent.Any(ix => !char.IsDigit(ix)))
                     return false;
             }
-            return true;
+            else if (parts.Length != 1)
+            {
+                return false;
+            }
+
+            // If we are this far then we just need to check that the coefficient.
+            return coefficient.All(ix => char.IsDigit(ix) || ix == '.');
+        }
+
+        /*
+         * Returns the string with the first character removed if the first character is 
+         * a '+' or '-', as long as that is not the only character in the string.
+         */
+        private static string SanitizeSign(string number)
+        {
+            if (number.Length > 1 && (number[0] == '-' || number[0] == '+'))
+            {
+                number = number.Substring(1);
+            }
+            return number;
         }
     }
 }


### PR DESCRIPTION
### Changes
- Added tests for new valid number formats.
- Changed the IsNumeric method to accept numbers in scientific notation.
- Changed the CompileNumber method to use double.tryParse for any numbers in scientific notation.

All numbers in scientific notation will be interpreted as doubles, this probably makes the most sense and the `long.TryParse` method doesn't work out of the box with scientific notation. 

With the changes Lizzie will accept a '+' or '-' character as the sign of a number (for both scientific notation and the normal notation), instead of just a '-'.

#27 